### PR TITLE
Fix social icons design issue

### DIFF
--- a/src/DancingGoat/Views/Contacts/_SocialLinks.cshtml
+++ b/src/DancingGoat/Views/Contacts/_SocialLinks.cshtml
@@ -3,7 +3,7 @@
 @foreach (var link in Model)
 {
     <a class="followus-link" href="@link.Fields.Url" target="_blank">
-        @Html.AttachmentImage(link.Fields.Icon, link.Fields.Title, "cafe-image-tile-image")
+        @Html.AttachmentImage(link.Fields.Icon, link.Fields.Title)
     </a>
 }
 


### PR DESCRIPTION
Social icons in the Dancing Goat footer were too large for some screen sizes.
