### PR TITLE
Fix client caching for static content when Preview is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@
 #### Fixed
 
 * Updated Kentico package description for NuGet.org.
+* Fix client caching for static content when Preview module is enabled.
+[#20](https://github.com/Kentico/Mvc/pull/20)
 
 ## Kentico.Core
 

--- a/src/Kentico.Content.Web.Mvc/Kentico.Content.Web.Mvc.csproj
+++ b/src/Kentico.Content.Web.Mvc/Kentico.Content.Web.Mvc.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Preview\IPreviewFeature.cs" />
     <Compile Include="Preview\PreviewFeature.cs" />
     <Compile Include="Preview\PreviewFeatureModule.cs" />
+    <Compile Include="Preview\PreviewOutputCacheFilter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Kentico.Content.Web.Mvc/Preview/PreviewFeatureModule.cs
+++ b/src/Kentico.Content.Web.Mvc/Preview/PreviewFeatureModule.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Web;
+using System.Web.Mvc;
 using System.Web.Helpers;
 
 using CMS.DocumentEngine;
@@ -21,6 +22,7 @@ namespace Kentico.Content.Web.Mvc
         public void Initialize(HttpApplication application)
         {
             application.BeginRequest += HandleBeginRequest;
+            GlobalFilters.Filters.Add(new PreviewOutputCacheFilter());
         }
 
 
@@ -29,7 +31,6 @@ namespace Kentico.Content.Web.Mvc
             var application = (HttpApplication)sender;
             var context = application.Context;
             var relativeFilePath = context.Request.AppRelativeCurrentExecutionFilePath.TrimStart('~');
-
 
             // Check whether the current request URL contains information about a preview mode
             if (HandleVirtualContext(ref relativeFilePath))
@@ -50,11 +51,6 @@ namespace Kentico.Content.Web.Mvc
 
                 // Remove preview mode information from the request URL
                 context.RewritePath("~" + relativeFilePath, context.Request.PathInfo, context.Request.Url.Query.TrimStart('?'));
-            }
-            else
-            {
-                // Add validation callback for the output cache item to ignore it in a preview mode
-                context.Response.Cache.AddValidationCallback(ValidateCacheItem, null);
             }
 
             var previewFeature = new PreviewFeature();
@@ -88,15 +84,6 @@ namespace Kentico.Content.Web.Mvc
             var query = new DocumentQuery().WhereEquals("DocumentWorkflowCycleGUID", identifier);
 
             return query.HasResults();
-        }
-
-
-        private static void ValidateCacheItem(HttpContext context, object data, ref HttpValidationStatus status)
-        {
-            if (context.Kentico().Preview().Enabled)
-            {
-                status = HttpValidationStatus.IgnoreThisRequest;
-            }
         }
     }
 }

--- a/src/Kentico.Content.Web.Mvc/Preview/PreviewOutputCacheFilter.cs
+++ b/src/Kentico.Content.Web.Mvc/Preview/PreviewOutputCacheFilter.cs
@@ -1,0 +1,32 @@
+﻿using System.Web;
+using System.Web.Mvc;
+
+using Kentico.Web.Mvc;
+
+namespace Kentico.Content.Web.Mvc
+{
+    /// <summary>
+    /// Adds validation callback for the output cache item to ignore it in a preview mode.
+    /// </summary>
+    internal class PreviewOutputCacheFilter : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext filterContext)
+        {
+            var context = filterContext.HttpContext;
+
+            if (!context.Kentico().Preview().Enabled)
+            {
+                context.Response.Cache.AddValidationCallback(new HttpCacheValidateHandler(ValidateCacheItem), null);
+            }
+        }
+
+
+        private static void ValidateCacheItem(HttpContext context, object data, ref HttpValidationStatus status)
+        {
+            if (context.Kentico().Preview().Enabled)
+            {
+                status = HttpValidationStatus.IgnoreThisRequest;
+            }
+        }
+    }
+}

--- a/src/Kentico.Content.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Content.Web.Mvc/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("430a1add-4583-459f-879c-a22a61e44a3b")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.2")]
+[assembly: AssemblyInformationalVersion("1.0.1")]
 
 [assembly: InternalsVisibleTo("Kentico.Content.Web.Mvc.Tests")]

--- a/src/Kentico.Content.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Content.Web.Mvc/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("430a1add-4583-459f-879c-a22a61e44a3b")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.2")]
 
 [assembly: InternalsVisibleTo("Kentico.Content.Web.Mvc.Tests")]


### PR DESCRIPTION
Moved the registration of the cache validation callback method to be processed by the MVC request pipeline.