### PR TITLE
MVCHF10-4 Increase AssemblyInformationalVersion to fix package builds

### DIFF
--- a/src/Kentico.Activities.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Activities.Web.Mvc/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using CMS;
 [assembly: Guid("23931d6f-d0a7-45ff-b238-ef392015b55c")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1.1")]

--- a/src/Kentico.Activities/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Activities/Properties/AssemblyInfo.cs
@@ -16,6 +16,6 @@ using CMS;
 [assembly: Guid("18b90426-774b-4159-a2f3-592b5f3ca2a2")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1.1")]
 
 [assembly: InternalsVisibleTo("Kentico.Activities.Tests")]

--- a/src/Kentico.CampaignLogging.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/src/Kentico.CampaignLogging.Web.Mvc/Properties/AssemblyInfo.cs
@@ -16,6 +16,6 @@ using CMS;
 [assembly: Guid("e721b72a-3c32-4a0d-bb03-e4eb1756aafe")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1.1")]
 
 [assembly: InternalsVisibleTo("Kentico.Activities.Tests")]

--- a/src/Kentico.ContactManagement/Properties/AssemblyInfo.cs
+++ b/src/Kentico.ContactManagement/Properties/AssemblyInfo.cs
@@ -13,4 +13,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("c38f0f75-8dbd-4d65-9cf4-3da992ab7413")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1.1")]

--- a/src/Kentico.Content.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Content.Web.Mvc/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("430a1add-4583-459f-879c-a22a61e44a3b")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1.1")]
 
 [assembly: InternalsVisibleTo("Kentico.Content.Web.Mvc.Tests")]

--- a/src/Kentico.Core/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Core/Properties/AssemblyInfo.cs
@@ -16,4 +16,4 @@ using CMS;
 [assembly: Guid("13b34040-a1cc-49f9-abfd-38f39664cf9f")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1.1")]

--- a/src/Kentico.Ecommerce/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Ecommerce/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("5047a2a8-707c-49f0-995b-15bd5456ab2f")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1.1")]
 
 [assembly: InternalsVisibleTo("Kentico.Ecommerce.Tests")]

--- a/src/Kentico.MediaLibrary/Properties/AssemblyInfo.cs
+++ b/src/Kentico.MediaLibrary/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("dcaa1096-aa1d-4a70-9b14-77ee7714e12a")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1.1")]
 
 [assembly: InternalsVisibleTo("Kentico.MediaLibrary.Tests")]

--- a/src/Kentico.Newsletters.Web.Mvc/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Newsletters.Web.Mvc/Properties/AssemblyInfo.cs
@@ -13,4 +13,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("4be77c2e-8f3d-4896-b00e-fa178e40bd7a")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.1")]
+[assembly: AssemblyInformationalVersion("1.0.1.1")]

--- a/src/Kentico.Newsletters/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Newsletters/Properties/AssemblyInfo.cs
@@ -13,4 +13,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("4be77c2e-8f3d-4896-b00e-fa178e40bd7a")]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.1")]
+[assembly: AssemblyInformationalVersion("2.0.1.1")]

--- a/src/Kentico.Search/Properties/AssemblyInfo.cs
+++ b/src/Kentico.Search/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: Guid("1ffef41a-db53-4353-ae78-15e128f72b8f")]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.1")]
+[assembly: AssemblyInformationalVersion("2.0.1.1")]
 
 [assembly: InternalsVisibleTo("Kentico.Search.Tests")]


### PR DESCRIPTION
Version not increased for Kentico.Glimpse, Kentico.Membership and Kentico.Web.Mvc packages because they have correct dependencies on NuGet.org since they were not rebuilt since the nuget version change on AppVeyor.